### PR TITLE
HT-6229: Allow module to ignore WAF associations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,10 @@ resource "aws_wafv2_web_acl_association" "default" {
 
   resource_arn = var.association_resource_arns[count.index]
   web_acl_arn  = join("", aws_wafv2_web_acl.default.*.arn)
+
+  lifecycle {
+    ignore_changes = ignore_waf_associations ? [resource_arn, ] : []
+  }
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "default" {

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ resource "aws_wafv2_web_acl_association" "default" {
   web_acl_arn  = join("", aws_wafv2_web_acl.default.*.arn)
 
   lifecycle {
-    ignore_changes = ignore_waf_associations ? [resource_arn, ] : []
+    ignore_changes = var.ignore_waf_associations ? [resource_arn] : []
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -479,3 +479,9 @@ variable "extended_s3_configuration" {
       The configuration for backup in Amazon S3. Required if s3_backup_mode is Enabled. Supports the same fields as s3_configuration object.
   DOC
 }
+
+variable "ignore_waf_associations" {
+  type        = bool
+  default     = false
+  description = "Some associated ARN's may be added to the WAF from other places, e.g. the rideshur-web ingress controller specifies association to the WAF via an annotation."
+}


### PR DESCRIPTION
## Jira
[Ticket](https://humnai.atlassian.net/browse/HT-6229)
## Motivation
* Sometimes, WAF associations will be created by an external element outside of Terraform. For example, enabling the WAF on a kubernetes ingress control via annotation.
* We would not want this Terraform module to overwrite these associations on it's next run through.
## Changes
* Add variable that will stop Terraform from overwriting WAF associations.

