### PR TITLE
HT-6229: Allow module to ignore WAF associations

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,18 @@
-resource "aws_wafv2_web_acl_association" "default" {
-  count = module.this.enabled && length(var.association_resource_arns) > 0 ? length(var.association_resource_arns) : 0
+resource "aws_wafv2_web_acl_association" "create_waf_associations" {
+  count = module.this.enabled && !var.ignore_waf_associations && length(var.association_resource_arns) > 0 ? length(var.association_resource_arns) : 0
+
+  resource_arn = var.association_resource_arns[count.index]
+  web_acl_arn  = join("", aws_wafv2_web_acl.default.*.arn)
+}
+
+resource "aws_wafv2_web_acl_association" "ignore_waf_associations" {
+  count = module.this.enabled && var.ignore_waf_associations && length(var.association_resource_arns) > 0 ? length(var.association_resource_arns) : 0
 
   resource_arn = var.association_resource_arns[count.index]
   web_acl_arn  = join("", aws_wafv2_web_acl.default.*.arn)
 
   lifecycle {
-    ignore_changes = var.ignore_waf_associations ? [resource_arn] : []
+    ignore_changes = [resource_arn]
   }
 }
 


### PR DESCRIPTION
## Jira
[Ticket](https://humnai.atlassian.net/browse/HT-6229)
## Motivation
* Sometimes, WAF associations will be created by an external element outside of Terraform. For example, enabling the WAF on a kubernetes ingress control via annotation.
* We would not want this Terraform module to overwrite these associations on it's next run through.
## Changes
* Add variable that will stop Terraform from overwriting WAF associations.
