### PR TITLE
HT-10654 Update attribute to support aws provider 5.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -25,8 +25,8 @@ resource "aws_kinesis_firehose_delivery_stream" "default" {
   extended_s3_configuration {
     role_arn            = var.extended_s3_configuration.role_arn
     bucket_arn          = var.extended_s3_configuration.bucket_arn
-    buffer_size         = var.extended_s3_configuration.buffer_size
-    buffer_interval     = var.extended_s3_configuration.buffer_interval
+    buffering_size      = var.extended_s3_configuration.buffering_size
+    buffering_interval  = var.extended_s3_configuration.buffering_interval
     compression_format  = var.extended_s3_configuration.compression_format
     prefix              = "${module.this.id}/"
     error_output_prefix = "error-${module.this.id}/"

--- a/rules.tf
+++ b/rules.tf
@@ -352,14 +352,6 @@ resource "aws_wafv2_web_acl" "default" {
           content {
             name        = managed_rule_group_statement.value.name
             vendor_name = managed_rule_group_statement.value.vendor_name
-
-            dynamic "excluded_rule" {
-              for_each = lookup(managed_rule_group_statement.value, "excluded_rule", null) != null ? toset(managed_rule_group_statement.value.excluded_rule) : []
-
-              content {
-                name = excluded_rule.value
-              }
-            }
           }
         }
       }
@@ -563,14 +555,6 @@ resource "aws_wafv2_web_acl" "default" {
 
           content {
             arn = rule_group_reference_statement.value.arn
-
-            dynamic "excluded_rule" {
-              for_each = lookup(rule_group_reference_statement.value, "excluded_rule", null) != null ? toset(rule_group_reference_statement.value.excluded_rule) : []
-
-              content {
-                name = excluded_rule.value
-              }
-            }
           }
         }
       }

--- a/variables.tf
+++ b/variables.tf
@@ -456,8 +456,8 @@ variable "extended_s3_configuration" {
   type = object({
     role_arn                             = string
     bucket_arn                           = string
-    buffer_size                          = number
-    buffer_interval                      = number
+    buffering_size                       = number
+    buffering_interval                   = number
     compression_format                   = string
   })
   default     = null
@@ -466,10 +466,10 @@ variable "extended_s3_configuration" {
       The ARN of the AWS credentials.
     bucket_arn:
       The ARN of the S3 bucket
-    buffer_size:
+    buffering_size:
       Buffer incoming data to the specified size, in MBs, before delivering it to the destination.
       The default value is 5. We recommend setting SizeInMBs to a value greater than the amount of data you typically ingest into the delivery stream in 10 seconds. For example, if you typically ingest data at 1 MB/sec set SizeInMBs to be 10 MB or higher.
-    buffer_interval:
+    buffering_interval:
       Buffer incoming data for the specified period of time, in seconds, before delivering it to the destination. The default value is 300.
     compression_format:
       The compression format. If no value is specified, the default is UNCOMPRESSED. Other supported values are GZIP, ZIP, Snappy, & HADOOP_SNAPPY.


### PR DESCRIPTION
## Jira
- [HT-10654](https://humnai.atlassian.net/browse/HT-10654)
## Changes
- Remove unsupported excluded_rule attribute from aws_wafv2_web_acl resource
Rename extended_s3_configuration buffering option to support new aws api
